### PR TITLE
Fix message classification for errors at root level

### DIFF
--- a/src/components/ValidationMessages.js
+++ b/src/components/ValidationMessages.js
@@ -5,12 +5,12 @@ var templateUrl = require("ngtemplate-loader!html-loader!./validation-messages.h
 function ValidationMessagesController() {
   // Only the "error" messages
   this.errorMessages = function(messages) {
-    return messages && messages.filter(a => a.dataPath);
+    return messages && messages.filter(a => typeof a.dataPath !== 'undefined');
   };
 
   // Only "simple" messages
   this.simpleMessages = function(messages) {
-    return messages && messages.filter(a => !a.dataPath);
+    return messages && messages.filter(a => typeof a.dataPath === 'undefined');
   }
 }
 

--- a/tests/components/ValidationMessages.spec.js
+++ b/tests/components/ValidationMessages.spec.js
@@ -57,4 +57,20 @@ describe('ValidationMessages', function() {
     expect(element[0].querySelectorAll("tbody tr")).to.have.length(3);
 
   });
+
+  it('correctly classifies simple and error messages', function() {
+    var element = $compile("<validation-messages></validation-messages>")($scope);
+    $rootScope.$digest();
+
+    var $ctrl = $scope.$$childHead.$ctrl;
+
+    expect($ctrl.simpleMessages([{ message: "foo" }])).to.have.length(1);
+    expect($ctrl.errorMessages([{ message: "foo" }])).to.have.length(0);
+
+    expect($ctrl.simpleMessages([{ message: "foo", "dataPath": "" }])).to.have.length(0);
+    expect($ctrl.errorMessages([{ message: "foo", "dataPath": "" }])).to.have.length(1);
+
+    expect($ctrl.simpleMessages([{ message: "foo", "dataPath": "bar" }])).to.have.length(0);
+    expect($ctrl.errorMessages([{ message: "foo", "dataPath": "bar" }])).to.have.length(1);
+  });
 });


### PR DESCRIPTION
Errors at root level, because they have `dataPath: ""`, are incorrectly displayed as simple messages, not error messages.