### PR TITLE
Link to the HTTPS versions of the sites

### DIFF
--- a/src/components/validation-messages.html
+++ b/src/components/validation-messages.html
@@ -13,7 +13,7 @@
     <tbody>
         <tr ng-repeat="message in $ctrl.simpleMessages($ctrl.messages)">
             <td ng-if="message.message" ng-bind="message.message"></td>
-            <td ng-if="message.message_tid" ng-bind="message.message_tid | translate:message.message_params"></td>
+            <td ng-if="message.message_tid" ng-bind-html="message.message_tid | translate:message.message_params"></td>
         </tr>
         <tr ng-repeat="message in $ctrl.errorMessages($ctrl.messages)">
             <td ng-bind="message.dataPath" class="error-path"></td>

--- a/www/translations/locale-en.json
+++ b/www/translations/locale-en.json
@@ -44,8 +44,8 @@
 
   "ERROR_SAMPLE_LOADING": "Error loading sample",
 
-  "ERROR_INVALID_JSON": "Document is invalid JSON. Try http://jsonlint.com to fix it.",
-  "ERROR_INVALID_YAML": "Document is invalid YAML. Try http://codebeautify.org/yaml-validator to fix it.",
+  "ERROR_INVALID_JSON": "Document is invalid JSON. Try https://jsonlint.com to fix it.",
+  "ERROR_INVALID_YAML": "Document is invalid YAML. Try https://codebeautify.org/yaml-validator to fix it.",
 
   "ERROR_INVALID_MARKUP": "Invalid markup language '{{markupLanguage}}'.",
   "ERROR_INVALID_VERSION": "Invalid schema version '{{specVersion}}'.",

--- a/www/translations/locale-en.json
+++ b/www/translations/locale-en.json
@@ -44,8 +44,8 @@
 
   "ERROR_SAMPLE_LOADING": "Error loading sample",
 
-  "ERROR_INVALID_JSON": "Document is invalid JSON. Try https://jsonlint.com to fix it.",
-  "ERROR_INVALID_YAML": "Document is invalid YAML. Try https://codebeautify.org/yaml-validator to fix it.",
+  "ERROR_INVALID_JSON": "Document is invalid JSON. Try <a href='https://jsonlint.com'>JSONLint</a> to fix it.",
+  "ERROR_INVALID_YAML": "Document is invalid YAML. Try <a href='https://codebeautify.org/yaml-validator'>YAML Validator</a> to fix it.",
 
   "ERROR_INVALID_MARKUP": "Invalid markup language '{{markupLanguage}}'.",
   "ERROR_INVALID_VERSION": "Invalid schema version '{{specVersion}}'.",


### PR DESCRIPTION
I'd hoped to make these hyperlinks too but from a quick test it didn't seem to work, is it as simple as changing them to ng-bind-html in https://github.com/nickcmaynard/jsonschemalint/blob/5a4dfe9377b7e04b695fd137c9d3bec826b24f78/src/components/validation-messages.html#L16 or will bad things happen when its trying to return some JSON or similar as a message?